### PR TITLE
Support boolean and nil arguments

### DIFF
--- a/lib/dnode/walk.rb
+++ b/lib/dnode/walk.rb
@@ -37,7 +37,7 @@ class Walk
                 @path.pop
             end
             return copy
-        elsif [ Numeric, String, Proc ].select{ |x| value.is_a? x }.any?
+        elsif [ Numeric, String, TrueClass, FalseClass, NilClass, Proc ].select{ |x| value.is_a? x }.any?
             return value
         else
             # only serve up the object's "own" methods


### PR DESCRIPTION
Adds support for boolean and nil objects as arguments.

For example, the client in something like
```ruby
# server
DNode.new({
    :f => proc { |cb| cb.call(false) }
}).listen(5050)

# client
DNode.new({}).connect(5050) do |remote|
    remote.f(proc { |x| puts x })
end
```
will now puts `=> false` instead of a Hash of the object's own methods.